### PR TITLE
Change the type declarations of GET-FORM and FIND-FORMS.

### DIFF
--- a/src/cl-forms.lisp
+++ b/src/cl-forms.lisp
@@ -716,7 +716,7 @@ Use RENDER-FIELD, RENDER-FIELD-LABEL, etc manually, after."
  (ftype (function (form) boolean) cl-forms:form-valid-p)
  (ftype (function (t) *) cl-forms:field-formatter)
  (ftype (function (form) list) form-errors)
- (ftype (function (symbol) form) get-form find-form)
+ (ftype (function (symbol &rest t) form) get-form find-form)
  (ftype (function (t &rest t) *) cl-forms:render-field-widget)
  (ftype (function (t) *) cl-forms:field-reader)
  (ftype (function (t) *) cl-forms:field-writer)


### PR DESCRIPTION
Both functions take a symbol argument but also an arbitrary number of additional arguments.