### PR TITLE
WIP: Ningle pluggable backend

### DIFF
--- a/cl-forms.ningle.asd
+++ b/cl-forms.ningle.asd
@@ -1,0 +1,10 @@
+(asdf:defsystem #:cl-forms.ningle
+  :serial t
+  :description "CL-FORMS ningle backend"
+  :author "Neil Munro"
+  :license "MIT"
+  :depends-on (#:ningle
+               #:cl-forms-core)
+  :components ((:module :src
+                        :components
+                        ((:file "ningle")))))

--- a/src/ningle.lisp
+++ b/src/ningle.lisp
@@ -16,7 +16,8 @@
   (when (forms::form-csrf-protection-p form)
     ;; Check the csrf token
     (let ((session-token (get-form-session-csrf-token form)))
-      (when (or (not session-token) (not (equalp session-token (cdr (assoc (form-csrf-field-name form) (request-post-parameters request) :test #'string=)))))
+      (when (or (not session-token)
+                (not (equalp session-token (cdr (assoc (form-csrf-field-name form) (request-post-parameters request) :test #'string=)))))
         ;; The form is not valid. Throw an error, but reset its CSRF token for next time
         (set-form-session-csrf-token form)
         (error "Invalid CSRF token"))))
@@ -33,7 +34,5 @@
   (lack/middleware/csrf:csrf-token ningle:*session*))
 
 (defmethod set-form-session-csrf-token ((form form))
-  ;; (hunchentoot:start-session)
-  ;; (setf (hunchentoot:session-value (form-session-csrf-entry form))
-  ;;       (make-csrf-token form)))
-  nil)
+  (remhash lack/middleware/csrf::*csrf-session-key* ningle:*session*)
+  (lack/middleware/csrf:csrf-token ningle:*session*))

--- a/src/ningle.lisp
+++ b/src/ningle.lisp
@@ -1,0 +1,38 @@
+(defpackage :cl-forms.ningle
+  (:nicknames :forms.ningle)
+  (:use :cl :forms)
+  (:export #:backend-request))
+
+(in-package :cl-forms.ningle)
+
+(defmethod backend-request ()
+  nil)
+
+(defun handle-request (&optional (form *form*) (request lack/request:request))
+  ;; (when (form-csrf-protection-p form)
+  ;;   ;; Check the csrf token
+  ;;   (let ((session-token (get-form-session-csrf-token form)))
+  ;;     (when (or (not session-token) (not (equalp session-token (cdr (assoc (form-csrf-field-name form) (lack/request:request-body-parameters request) :test #'string=)))))
+  ;;       ;; The form is not valid. Throw an error, but reset its CSRF token for next time
+  ;;       (set-form-session-csrf-token form)
+  ;;       (error "Invalid CSRF token"))))
+
+  ;; (let ((post-parameters (lack/request:request-body-parameters request)))
+  ;;   (loop for field in (form-fields form)
+  ;;         do (field-read-from-request (cdr field) form
+  ;;                                     post-parameters))))
+  nil)
+
+(defmethod request-post-parameters ((request lack/request:request))
+  ;; (hunchentoot:post-parameters request))
+  nil)
+
+(defmethod get-form-session-csrf-token ((form form))
+  ;; (hunchentoot:session-value (form-session-csrf-entry form)))
+  nil)
+
+(defmethod set-form-session-csrf-token ((form form))
+  ;; (hunchentoot:start-session)
+  ;; (setf (hunchentoot:session-value (form-session-csrf-entry form))
+  ;;       (make-csrf-token form)))
+  nil)

--- a/src/ningle.lisp
+++ b/src/ningle.lisp
@@ -6,7 +6,7 @@
 (in-package :cl-forms.ningle)
 
 (defmethod backend-request ()
-  nil)
+  ningle:*request*)
 
 (defun handle-request (&optional (form *form*) (request lack/request:request))
   ;; (when (form-csrf-protection-p form)

--- a/src/ningle.lisp
+++ b/src/ningle.lisp
@@ -30,9 +30,7 @@
   (lack/request:request-body-parameters request))
 
 (defmethod get-form-session-csrf-token ((form form))
-  ;; (format t (forms::form-session-csrf-entry form))
-  ;; (hunchentoot:session-value (form-session-csrf-entry form)))
-  nil)
+  (lack/middleware/csrf:csrf-token ningle:*session*))
 
 (defmethod set-form-session-csrf-token ((form form))
   ;; (hunchentoot:start-session)

--- a/src/ningle.lisp
+++ b/src/ningle.lisp
@@ -1,33 +1,36 @@
 (defpackage :cl-forms.ningle
   (:nicknames :forms.ningle)
   (:use :cl :forms)
-  (:export #:backend-request))
+  (:export #:backend-request
+           #:handle-request
+           #:request-post-parameters
+           #:get-form-session-csrf-token
+           #:set-form-session-csrf-token))
 
 (in-package :cl-forms.ningle)
 
 (defmethod backend-request ()
   ningle:*request*)
 
-(defun handle-request (&optional (form *form*) (request lack/request:request))
-  ;; (when (form-csrf-protection-p form)
-  ;;   ;; Check the csrf token
-  ;;   (let ((session-token (get-form-session-csrf-token form)))
-  ;;     (when (or (not session-token) (not (equalp session-token (cdr (assoc (form-csrf-field-name form) (lack/request:request-body-parameters request) :test #'string=)))))
-  ;;       ;; The form is not valid. Throw an error, but reset its CSRF token for next time
-  ;;       (set-form-session-csrf-token form)
-  ;;       (error "Invalid CSRF token"))))
+(defun handle-request (&optional (form *form*) (request ningle:*request*))
+  (when (forms::form-csrf-protection-p form)
+    ;; Check the csrf token
+    (let ((session-token (get-form-session-csrf-token form)))
+      (when (or (not session-token) (not (equalp session-token (cdr (assoc (form-csrf-field-name form) (request-post-parameters request) :test #'string=)))))
+        ;; The form is not valid. Throw an error, but reset its CSRF token for next time
+        (set-form-session-csrf-token form)
+        (error "Invalid CSRF token"))))
 
-  ;; (let ((post-parameters (lack/request:request-body-parameters request)))
-  ;;   (loop for field in (form-fields form)
-  ;;         do (field-read-from-request (cdr field) form
-  ;;                                     post-parameters))))
-  nil)
+  (let ((post-parameters (lack/request:request-body-parameters request)))
+    (loop for field in (form-fields form)
+          do (forms::field-read-from-request (cdr field) form
+                                      post-parameters))))
 
 (defmethod request-post-parameters ((request lack/request:request))
-  ;; (hunchentoot:post-parameters request))
-  nil)
+  (lack/request:request-body-parameters request))
 
 (defmethod get-form-session-csrf-token ((form form))
+  ;; (format t (forms::form-session-csrf-entry form))
   ;; (hunchentoot:session-value (form-session-csrf-entry form)))
   nil)
 


### PR DESCRIPTION
I have implemented what I believe is required for a ningle pluggable backend, however there's a small issue I may need some help with.

When enabling the ningle csrf middleware, is allows for setting the name of the csrf field. `(:csrf :form-token "csrf-token")`, it sets the csrf information in the ningle session object (which will use the hunchentoot, woo, wookie etc sessions under the hood). 

When I enable the csrf middleware for ningle (which presumably means that cl-forms won't want to manage its own csrf tokens), the form renders csrf tokens that are not the ones ningle expects. 

Is there a method I should override to deligate the csrf token generation to ningle and not the default hunchentoot?